### PR TITLE
replace reference to `dagger version` with SDK type + version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,8 +32,8 @@ body:
     id: dagger-version
     attributes:
       label: Dagger version
-      description: Please paste the output of `dagger version`
-      placeholder: e.g. dagger 0.2.8 (92c8c7a2) darwin/arm64
+      description: Please paste the type + version of SDK, or the git commit number
+      placeholder: e.g. NodeJS v0.3.0 | Go v0.4.0 | Python v0.2.0 | 5219a37e
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -29,19 +29,19 @@ body:
     validations:
       required: false
   - type: input
-    id: dagger-version
+    id: sdk-version
     attributes:
-      label: Dagger version
-      description: Please paste the type + version of SDK, or the git commit number
-      placeholder: e.g. NodeJS v0.3.0 | Go v0.4.0 | Python v0.2.0 | 5219a37e
+      label: SDK version
+      description: Which SDK have you encountered this issue with?
+      placeholder: e.g. Go SDK v0.4.2, Python SDK v0.2.1, Node.js SDK v0.3.0, etc.
     validations:
       required: true
   - type: input
     id: os-version
     attributes:
       label: OS version
-      description: Which OS version are you running `dagger` on?
-      placeholder: e.g. macOS 12.3, Ubuntu 22.04, Windows 11, etc.
+      description: Which OS version are you running on?
+      placeholder: e.g. macOS 12.6, Ubuntu 22.04, Windows 11, etc.
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
It doesn't make sense to have reference to `dagger version` for now.