### PR TITLE
Move dagger version as the second required input

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -14,6 +14,14 @@ body:
       description: What happened? What did you expect to happen?
     validations:
       required: true
+  - type: input
+    id: version
+    attributes:
+      label: Dagger version
+      description: Output of `dagger version`
+      placeholder: dagger v0.9.4 (registry.dagger.io/engine) darwin/amd64
+    validations:
+      required: true
   - type: textarea
     id: steps
     attributes:
@@ -28,13 +36,6 @@ body:
       description: Please paste the log output
     validations:
       required: false
-  - type: input
-    id: version
-    attributes:
-      label: dagger version
-      description: Output of `dagger version`
-    validations:
-      required: true
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
So that we keep the required inputs together, before the optional ones.

Also add a placeholder example for the `dagger version` ouput.